### PR TITLE
Fix imports for lab module

### DIFF
--- a/lab/__init__.py
+++ b/lab/__init__.py
@@ -1,1 +1,4 @@
 from .project import Project
+from . import keras
+from . import server
+from . import sklearn


### PR DESCRIPTION
Address issue 'module "lab" has no attribute "keras'" by importing required modules in the lab module's __init__.py file.